### PR TITLE
Various fixes/changes

### DIFF
--- a/worlds/aquaria/Items.py
+++ b/worlds/aquaria/Items.py
@@ -8,13 +8,15 @@ from typing import Optional
 from enum import Enum
 from BaseClasses import Item, ItemClassification
 
+
 class ItemType(Enum):
     """
-    Used to indicate to the multi-world if an item is usefull or not
+    Used to indicate to the multi-world if an item is useful or not
     """
     NORMAL = 0
     PROGRESSION = 1
     JUNK = 2
+
 
 class ItemGroup(Enum):
     """
@@ -28,6 +30,7 @@ class ItemGroup(Enum):
     SONG = 5
     TURTLE = 6
 
+
 class AquariaItem(Item):
     """
     A single item in the Aquaria game.
@@ -40,22 +43,23 @@ class AquariaItem(Item):
         """
         Initialisation of the Item
         :param name: The name of the item
-        :param classification: If the item is usefull or not
+        :param classification: If the item is useful or not
         :param code: The ID of the item (if None, it is an event)
         :param player: The ID of the player in the multiworld
         """
         super().__init__(name, classification, code, player)
 
+
 class ItemData:
     """
     Data of an item.
     """
-    id:int
-    count:int
-    type:ItemType
-    group:ItemGroup
+    id: int
+    count: int
+    type: ItemType
+    group: ItemGroup
 
-    def __init__(self, id:int, count:int, type:ItemType, group:ItemGroup):
+    def __init__(self, id: int, count: int, type: ItemType, group: ItemGroup):
         """
         Initialisation of the item data
         @param id: The item ID
@@ -67,6 +71,7 @@ class ItemData:
         self.count = count
         self.type = type
         self.group = group
+
 
 """Information data for every (not event) item."""
 item_table = {
@@ -207,4 +212,3 @@ item_table = {
     "Transturtle Simon says": ItemData(698132, 1, ItemType.PROGRESSION, ItemGroup.TURTLE),  # transport_forest05
     "Transturtle Arnassi ruins": ItemData(698133, 1, ItemType.PROGRESSION, ItemGroup.TURTLE),  # transport_seahorse
 }
-

--- a/worlds/aquaria/Locations.py
+++ b/worlds/aquaria/Locations.py
@@ -129,7 +129,7 @@ class AquariaLocations:
 
     locations_openwater_bl = {
         "Open water bottom left area, bulb behind the chomper fish": 698011,
-        "Open water bottom left area, bulb inside the downest fish pass": 698010,
+        "Open water bottom left area, bulb inside the lowest fish pass": 698010,
     }
 
     locations_skeleton_path = {

--- a/worlds/aquaria/Options.py
+++ b/worlds/aquaria/Options.py
@@ -108,7 +108,7 @@ class LightNeededToGetToDarkPlaces(DefaultOnToggle):
 
 class BindSongNeededToGetUnderRockBulb(Toggle):
     """
-    Make sure that the bind song can be acquired before having to obtain sing bulb under rocks.
+    Make sure that the bind song can be acquired before having to obtain sing bulbs under rocks.
     """
     display_name = "Bind song needed to get sing bulbs under rocks"
 

--- a/worlds/aquaria/Options.py
+++ b/worlds/aquaria/Options.py
@@ -10,9 +10,8 @@ from Options import Toggle, Choice, Range, DeathLink, PerGameCommonOptions, Defa
 
 class IngredientRandomizer(Choice):
     """
-    Randomize Ingredients. Select if the simple ingredients (that does not have
-    a recipe) should be randomized. If 'common_ingredients' is selected, the
-    randomization will exclude the "Red Bulb", "Special Bulb" and "Rukh Egg".
+    Select if the simple ingredients (that do not have a recipe) should be randomized.
+    If "Common Ingredients" is selected, the randomization will exclude the "Red Bulb", "Special Bulb" and "Rukh Egg".
     """
     display_name = "Randomize Ingredients"
     option_off = 0
@@ -43,13 +42,13 @@ class EarlyEnergyForm(DefaultOnToggle):
 
 
 class AquarianTranslation(Toggle):
-    """Translate to English the Aquarian scripture in the game."""
+    """Translate the Aquarian scripture in the game into English."""
     display_name = "Translate Aquarian"
 
 
 class BigBossesToBeat(Range):
     """
-    A number of big bosses to beat before having access to the creator (the final boss). The big bosses are
+    The number of big bosses to beat before having access to the creator (the final boss). The big bosses are
     "Fallen God", "Mithalan God", "Drunian God", "Sun God" and "The Golem".
     """
     display_name = "Big bosses to beat"
@@ -60,12 +59,12 @@ class BigBossesToBeat(Range):
 
 class MiniBossesToBeat(Range):
     """
-    A number of Minibosses to beat before having access to the creator (the final boss). Mini bosses are
+    The number of minibosses to beat before having access to the creator (the final boss). The minibosses are
     "Nautilus Prime", "Blaster Peg Prime", "Mergog", "Mithalan priests", "Octopus Prime", "Crabbius Maximus",
-    "Mantis Shrimp Prime" and "King Jellyfish God Prime". Note that the Energy statue and Simon says are not
-    mini bosses.
+    "Mantis Shrimp Prime" and "King Jellyfish God Prime".
+    Note that the Energy Statue and Simon Says are not minibosses.
     """
-    display_name = "Mini bosses to beat"
+    display_name = "Minibosses to beat"
     range_start = 0
     range_end = 8
     default = 0
@@ -73,47 +72,50 @@ class MiniBossesToBeat(Range):
 
 class Objective(Choice):
     """
-    The game objective can be only to kill the creator or to kill the creator
-    and having obtained the three every secret memories
+    The game objective can be to kill the creator or to kill the creator after obtaining all three secret memories.
     """
     display_name = "Objective"
     option_kill_the_creator = 0
     option_obtain_secrets_and_kill_the_creator = 1
     default = 0
 
+
 class SkipFirstVision(Toggle):
     """
-    The first vision in the game; where Naija transform to Energy Form and get fload by enemy; is quite cool but
+    The first vision in the game, where Naija transforms into Energy Form and gets flooded by enemies, is quite cool but
     can be quite long when you already know what is going on. This option can be used to skip this vision.
     """
-    display_name = "Skip first Naija's vision"
+    display_name = "Skip Naija's first vision"
+
 
 class NoProgressionHardOrHiddenLocation(Toggle):
     """
-    Make sure that there is no progression items at hard to get or hard to find locations.
-    Those locations that will be very High location (that need beast form, soup and skill to get), every
-    location in the bubble cave, locations that need you to cross a false wall without any indication, Arnassi
-    race, bosses and mini-bosses. Usefull for those that want a casual run.
+    Make sure that there are no progression items at hard-to-reach or hard-to-find locations.
+    Those locations are very High locations (that need beast form, soup and skill to get),
+    every location in the bubble cave, locations where need you to cross a false wall without any indication,
+    the Arnassi race, bosses and minibosses. Useful for those that want a more casual run.
     """
     display_name = "No progression in hard or hidden locations"
 
+
 class LightNeededToGetToDarkPlaces(DefaultOnToggle):
     """
-    Make sure that the sun form or the dumbo pet can be aquired before getting to dark places. Be aware that navigating
-    in dark place without light is extremely difficult.
+    Make sure that the sun form or the dumbo pet can be acquired before getting to dark places.
+    Be aware that navigating in dark place without light is extremely difficult.
     """
     display_name = "Light needed to get to dark places"
 
+
 class BindSongNeededToGetUnderRockBulb(Toggle):
     """
-    Make sure that the bind song can be aquired before having to obtain sing bulb under rocks.
+    Make sure that the bind song can be acquired before having to obtain sing bulb under rocks.
     """
     display_name = "Bind song needed to get sing bulbs under rocks"
 
 
 class UnconfineHomeWater(Choice):
     """
-    Open the way out of Home water area so that Naija can go to open water and beyond without the bind song.
+    Open the way out of the Home water area so that Naija can go to open water and beyond without the bind song.
     """
     display_name = "Unconfine Home Water Area"
     option_off = 0

--- a/worlds/aquaria/Regions.py
+++ b/worlds/aquaria/Regions.py
@@ -5,7 +5,7 @@ Description: Used to manage Regions in the Aquaria game multiworld randomizer
 """
 
 from typing import Dict, Optional
-from BaseClasses import MultiWorld, Region, Entrance, ItemClassification, LocationProgressType, CollectionState
+from BaseClasses import MultiWorld, Region, Entrance, ItemClassification, CollectionState
 from .Items import AquariaItem
 from .Locations import AquariaLocations, AquariaLocation
 from .Options import AquariaOptions
@@ -222,8 +222,6 @@ class AquariaRegions:
         if locations is not None:
             region.add_locations(locations, AquariaLocation)
         return region
-
-
 
     def __create_home_water_area(self) -> None:
         """
@@ -941,7 +939,7 @@ class AquariaRegions:
         """
         Add secrets events to the `world`
         """
-        self.__add_event_location(self.first_secret, # Doit ajouter une région pour le "first secret"
+        self.__add_event_location(self.first_secret,  # Doit ajouter une région pour le "first secret"
                                   "First secret",
                                   "First secret obtained")
         self.__add_event_location(self.mithalas_city,
@@ -1095,12 +1093,10 @@ class AquariaRegions:
         add_rule(self.multiworld.get_entrance("Veil left of sun temple to Sun temple left area", self.player),
                  lambda state: _has_light(state, self.player) or _has_sun_crystal(state, self.player))
 
-
-
     def __adjusting_manual_rules(self) -> None:
         add_rule(self.multiworld.get_location("Mithalas cathedral, Mithalan Dress", self.player),
                  lambda state: _has_beast_form(state, self.player))
-        add_rule(self.multiworld.get_location("Open water bottom left area, bulb inside the downest fish pass", self.player),
+        add_rule(self.multiworld.get_location("Open water bottom left area, bulb inside the lowest fish pass", self.player),
                  lambda state: _has_fish_form(state, self.player))
         add_rule(self.multiworld.get_location("Kelp forest bottom left area, Walker baby", self.player),
                  lambda state: _has_spirit_form(state, self.player))
@@ -1132,9 +1128,6 @@ class AquariaRegions:
         add_rule(self.multiworld.get_location("Arnassi ruins, Arnassi Armor", self.player),
                  lambda state: _has_fish_form(state, self.player) and
                                _has_spirit_form(state, self.player))
-
-
-
 
     def __no_progression_hard_or_hidden_location(self) -> None:
         self.multiworld.get_location("Energy temple boss area, Fallen god tooth",

--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -5,7 +5,7 @@ Description: Main module for Aquaria game multiworld randomizer
 """
 
 from typing import List, Dict, ClassVar, Any
-from ..AutoWorld import World, WebWorld
+from worlds.AutoWorld import World, WebWorld
 from BaseClasses import Tutorial, MultiWorld, ItemClassification
 from .Items import item_table, AquariaItem, ItemType, ItemGroup
 from .Locations import location_table
@@ -114,7 +114,7 @@ class AquariaWorld(World):
 
     def create_item(self, name: str) -> AquariaItem:
         """
-        Create an AquariaItem using `name' as item name.
+        Create an AquariaItem using 'name' as item name.
         """
         result: AquariaItem
         try:

--- a/worlds/aquaria/docs/en_Aquaria.md
+++ b/worlds/aquaria/docs/en_Aquaria.md
@@ -11,39 +11,39 @@ options page link: [Aquaria Player Options Page](../player-options).
 ## What does randomization do to this game?
 The locations in the randomizer are:
 
-- All sing bulbs;
-- All Mithalas Urns;
-- All Sunken City crates;
-- Collectible treasure locations (including pet eggs and costumes);
-- Beating Simon says;
-- Li cave;
-- Every Transportation Turtle (also called transturtle);
-- Locations where you get songs,
-  * Erulian spirit cristal,
-  * Energy status mini-boss,
-  * Beating Mithalan God boss,
-  * Fish cave puzzle,
-  * Beating Drunian God boss,
-  * Beating Sun God boss,
-  * Breaking Li cage in the body
+- All sing bulbs
+- All Mithalas Urns
+- All Sunken City crates
+- Collectible treasure locations (including pet eggs and costumes)
+- Beating Simon says
+- Li cave
+- Every Transportation Turtle (also called transturtle)
+- Locations where you get songs:
+    * Erulian spirit cristal
+    * Energy status mini-boss
+    * Beating Mithalan God boss
+    * Fish cave puzzle
+    * Beating Drunian God boss
+    * Beating Sun God boss
+    * Breaking Li cage in the body
 
 Note that, unlike the vanilla game, when opening sing bulbs, Mithalas urns and Sunken City crates,
-nothing will come out of them. The moment those bulbs, urns and crates are opened, the location is considered received.
+nothing will come out of them. The moment those bulbs, urns and crates are opened, the location is considered checked.
 
 The items in the randomizer are:
-- Dishes (used to learn recipes*);
-- Some ingredients;
-- The Wok (third plate used to cook 3 ingredients recipes everywhere);
-- All collectible treasure (including pet eggs and costumes);
-- Li and Li song;
-- All songs (other than Li's song since it is learned when Li is obtained);
-- Transportation to transturtles.
+- Dishes (used to learn recipes)<sup>*</sup>
+- Some ingredients
+- The Wok (third plate used to cook 3-ingredient recipes everywhere)
+- All collectible treasure (including pet eggs and costumes)
+- Li and Li's song
+- All songs (other than Li's song since it is learned when Li is obtained)
+- Transportation to transturtles
 
 Also, there is the option to randomize every ingredient drops (from fishes, monsters
 or plants).
 
-*Note that, unlike in the vanilla game, the recipes for dishes (other than the Sea Loaf)
-cannot be cooked (and learn) before being obtained as randomized items. Also, enemies and plants
+<sup>*</sup> Note that, unlike in the vanilla game, the recipes for dishes (other than the Sea Loaf)
+cannot be cooked (or learned) before being obtained as randomized items. Also, enemies and plants
 that drop dishes that have not been learned before will drop ingredients of this dish instead.
 
 ## What is the goal of the game?
@@ -57,8 +57,8 @@ Any items specified above can be in another player's world.
 No visuals are shown when finding locations other than collectible treasure.
 For those treasures, the visual of the treasure is visually unchanged.
 After collecting a location check, a message will be shown to inform the player
-what has been collected, and who will receive it.
+what has been collected and who will receive it.
 
 ## When the player receives an item, what happens?
 When you receive an item, a message will pop up to inform you where you received
-the item from, and which one it is.
+the item from and which one it was.

--- a/worlds/aquaria/docs/setup_en.md
+++ b/worlds/aquaria/docs/setup_en.md
@@ -18,8 +18,7 @@ the original game will stop working. Copying the folder will guarantee that the 
 Also, in Windows, the save files are stored in the Aquaria folder. So copying the Aquaria folder for every Multiworld
 game you play will make sure that every game has its own save game.
 
-Unzip the Aquaria randomizer release and copy all unzipped files in the Aquaria game folder. The unzipped files
-are:
+Unzip the Aquaria randomizer release and copy all unzipped files in the Aquaria game folder. The unzipped files are:
 - aquaria_randomizer.exe
 - OpenAL32.dll
 - override (directory)
@@ -76,8 +75,7 @@ the preceding commands will launch the game multiple times.
 First, you should copy the original Aquaria folder game. The randomizer will possibly modify the game so that
 the original game will stop working. Copying the folder will guarantee that the original game keeps on working.
 
-Untar the Aquaria randomizer release and copy all extracted files in the Aquaria game folder. The extracted
-files are:
+Untar the Aquaria randomizer release and copy all extracted files in the Aquaria game folder. The extracted files are:
 - aquaria_randomizer
 - override (directory)
 - usersettings.xml

--- a/worlds/aquaria/docs/setup_en.md
+++ b/worlds/aquaria/docs/setup_en.md
@@ -2,9 +2,12 @@
 
 ## Required Software
 
-- The original Aquaria Game (buyable from a lot of online game seller);
+- The original Aquaria Game (buyable from a lot of online game seller)
 - The [Aquaria randomizer](https://github.com/tioui/Aquaria_Randomizer/releases)
-- Optional, for sending [commands](/tutorial/Archipelago/commands/en) like `!hint`: the TextClient from [the most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases)
+
+## Optional Software
+- 
+- For sending [commands](/tutorial/Archipelago/commands/en) like `!hint`: the TextClient from [the most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases)
 
 ## Installation and execution Procedures
 
@@ -13,10 +16,10 @@
 First, you should copy the original Aquaria folder game. The randomizer will possibly modify the game so that
 the original game will stop working. Copying the folder will guarantee that the original game keeps on working.
 Also, in Windows, the save files are stored in the Aquaria folder. So copying the Aquaria folder for every Multiworld
-game you play will make sure that every game has their own save game.
+game you play will make sure that every game has its own save game.
 
 Unzip the Aquaria randomizer release and copy all unzipped files in the Aquaria game folder. The unzipped files
-are those:
+are:
 - aquaria_randomizer.exe
 - OpenAL32.dll
 - override (directory)
@@ -25,11 +28,11 @@ are those:
 - wrap_oal.dll
 - cacert.pem
 
-If there is a conflict between file in the original game folder and the unzipped files, you should override
-the original files with the one of the unzipped randomizer.
+If there is a conflict between files in the original game folder and the unzipped files, you should overwrite
+the original files with the ones from the unzipped randomizer.
 
 Finally, to launch the randomizer, you must use the command line interface (you can open the command line interface
-by writing `cmd` in the address bar of the Windows file explorer). Here is the command line to use to start the
+by typing `cmd` in the address bar of the Windows File Explorer). Here is the command line used to start the
 randomizer:
 
 ```bash
@@ -44,8 +47,8 @@ aquaria_randomizer.exe  --name YourName --server theServer:thePort --password th
 
 ### Linux when using the AppImage
 
-If you use the AppImage, just copy it in the Aquaria game folder. You then have to make it executable. You
-can do that from command line by using 
+If you use the AppImage, just copy it into the Aquaria game folder. You then have to make it executable. You
+can do that from command line by using:
 
 ```bash
 chmod +x Aquaria_Randomizer-*.AppImage
@@ -65,7 +68,7 @@ or, if the room has a password:
 ./Aquaria_Randomizer-*.AppImage --name YourName --server theServer:thePort --password thePassword
 ```
 
-Note that you should not have multiple Aquaria_Randomizer AppImage file in the same folder. If this situation occurred,
+Note that you should not have multiple Aquaria_Randomizer AppImage file in the same folder. If this situation occurs,
 the preceding commands will launch the game multiple times.
 
 ### Linux when using the tar file
@@ -74,23 +77,23 @@ First, you should copy the original Aquaria folder game. The randomizer will pos
 the original game will stop working. Copying the folder will guarantee that the original game keeps on working.
 
 Untar the Aquaria randomizer release and copy all extracted files in the Aquaria game folder. The extracted
-files are those:
+files are:
 - aquaria_randomizer
 - override (directory)
 - usersettings.xml
 - cacert.pem
 
-If there is a conflict between file in the original game folder and the extracted files, you should override
-the original files with the one of the extracted randomizer files.
+If there is a conflict between files in the original game folder and the extracted files, you should overwrite
+the original files with the ones from the extracted randomizer files.
 
-Then, you should use your system package manager to install liblua5, libogg, libvorbis, libopenal and libsdl2.
+Then, you should use your system package manager to install `liblua5`, `libogg`, `libvorbis`, `libopenal` and `libsdl2`.
 On Debian base system (like Ubuntu), you can use the following command:
 
 ```bash
 sudo apt install liblua5.1-0-dev libogg-dev libvorbis-dev libopenal-dev libsdl2-dev
 ```
 
-Also, if there is some `.so` files in the Aquaria original game folder (`libgcc_s.so.1`, `libopenal.so.1`,
+Also, if there are certain `.so` files in the original Aquaria game folder (`libgcc_s.so.1`, `libopenal.so.1`,
 `libSDL-1.2.so.0` and `libstdc++.so.6`), you should remove them from the Aquaria Randomizer game folder. Those are
 old libraries that will not work on the recent build of the randomizer.
 
@@ -106,7 +109,7 @@ or, if the room has a password:
 ./aquaria_randomizer --name YourName --server theServer:thePort --password thePassword
 ```
 
-Note: If you have a permission denied error when using the command line, you can use this command line to be
+Note: If you get a permission denied error when using the command line, you can use this command to be
 sure that your executable has executable permission:
 
 ```bash

--- a/worlds/aquaria/test/__init__.py
+++ b/worlds/aquaria/test/__init__.py
@@ -25,7 +25,7 @@ after_home_water_locations = [
     "Open water top right area, bulb in the turtle room",
     "Open water top right area, Transturtle",
     "Open water bottom left area, bulb behind the chomper fish",
-    "Open water bottom left area, bulb inside the downest fish pass",
+    "Open water bottom left area, bulb inside the lowest fish pass",
     "Open water skeleton path, bulb close to the right exit",
     "Open water skeleton path, bulb behind the chomper fish",
     "Open water skeleton path, King skull",

--- a/worlds/aquaria/test/test_fish_form_access.py
+++ b/worlds/aquaria/test/test_fish_form_access.py
@@ -21,7 +21,7 @@ class FishFormAccessTest(AquariaTestBase):
             "Mithalas city, urn inside a home fish pass",
             "Kelp Forest top right area, bulb in the top fish pass",
             "The veil bottom area, Verse egg",
-            "Open water bottom left area, bulb inside the downest fish pass",
+            "Open water bottom left area, bulb inside the lowest fish pass",
             "Kelp Forest top left area, bulb close to the Verse egg",
             "Kelp forest top left area, Verse egg",
             "Mermog cave, bulb in the left part of the cave",


### PR DESCRIPTION
## What is this fixing or adding?

Spacing, formatting, spelling/grammar, 

Especially of note: "Open water bottom left area, bulb inside the downest fish pass" became "Open water bottom left area, bulb inside the lowest fish pass" (downest -> lowest)

Two other things I noticed but didn't change because I'm unsure what to do:
* The description for "Dish Randomizer" should probably be updated, it's unclear what it refers to
* Early Energy Form says "Force the Energy Form to be in a location before leaving the areas around the Home Water." but this could be misleading to players as the item isn't made `early` which is a special Archipelago term, instead it is logically required, which means it could still be at the very end of the multiworld.

## How was this tested?

Unit tests, PyCharm, and a few generations and looking at WebHost.
